### PR TITLE
WRF container fixes

### DIFF
--- a/raspuri2_wrf/README.md
+++ b/raspuri2_wrf/README.md
@@ -10,9 +10,12 @@ This will create an image with all the dependencies and download the WRF and WPS
 
     sudo docker run -it oriolcervello/raspuri:image bash
 
-And compile the WRF and WPS: (you can see in configRASPURI.sh that there are the paths of some dependencies, if they are updated to newer versions 1.12 ->1.13 the path needs to be changed):
+And compile the WRF and WPS:
 
-    bash configRASPURI.sh
+    cd /root && ./configRASPURI.sh
+
+At the first set of prompts, pick 34 (GNU (gfortran/gcc), dmpar), then 1 (basic nesting).
+At the second set of prompts, pick 1 (serial gfortran with GRIB2)
 
 Once finished we can exit the container, and create an image form it
 

--- a/raspuri2_wrf/configRASPURI.sh
+++ b/raspuri2_wrf/configRASPURI.sh
@@ -34,13 +34,16 @@ eval $(~/.linuxbrew/bin/brew shellenv)
 #check versions
 NETCDF="$(echo /root/.linuxbrew/Cellar/netcdf/*)"
 HDF5="$(echo /root/.linuxbrew/Cellar/hdf5/*)"
+
+# number of cores to parallel compile
+J="-j $(nproc)"
+
 export NETCDF \
 HDF5 \
 JASPERLIB=/root/grib2/lib \
 JASPERINC=/root/grib2/include \
 WGRIB=/root/grib2 \
-# number of cores to parallel compile
-J='-j 4' \
+J \
 CC=gcc-9 \
 CXX=g++-9 \
 FC=gfortran-9 \

--- a/raspuri2_wrf/configRASPURI.sh
+++ b/raspuri2_wrf/configRASPURI.sh
@@ -56,12 +56,12 @@ cd WRF
 ./configure 
 #34 1  (dmpar GNU gfortran)
 ./compile em_real
-# fer que sigui compilador v9
-#SFC             =       gfortran
-#SCC             =       gcc
-#CCOMP           =       gcc
 cd ../WPS
 ./clean
+# WPS' menu ignores our CC and FC and sets "gcc" and "gfortran" as the name of the compilers.
+# But gfortran points to gfortran10 which can't build WPS, and gcc is the host's GCC 7, not the homebrew version
+# Fix those choices before we run configure:
+sed -i.bak -e 's/SFC\s*=\s*gfortran$/SFC=gfortran-9/' -e 's/SCC\s*=\s*gcc$/SCC=gcc-9/' arch/configure.defaults
 ./configure
 #1 (serial gfortran with GRIB2)
 ./compile

--- a/raspuri2_wrf/configRASPURI.sh
+++ b/raspuri2_wrf/configRASPURI.sh
@@ -32,8 +32,10 @@
 
 eval $(~/.linuxbrew/bin/brew shellenv) 
 #check versions
-export NETCDF=/root/.linuxbrew/Cellar/netcdf/4.7.4 \
-HDF5=/root/.linuxbrew/Cellar/hdf5/1.12.0 \
+NETCDF="$(echo /root/.linuxbrew/Cellar/netcdf/*)"
+HDF5="$(echo /root/.linuxbrew/Cellar/hdf5/*)"
+export NETCDF \
+HDF5 \
 JASPERLIB=/root/grib2/lib \
 JASPERINC=/root/grib2/include \
 WGRIB=/root/grib2 \


### PR DESCRIPTION
Some small fixes to the WRF container so that it can build successfully with the newest releases of the Homebrew packages.

Now correctly picks gfortran-9/gcc-9 for building WPS even when `gfortran` points to `gfortran-10`/`gcc` points to `gcc-7`.